### PR TITLE
Fix locking issue and optimize a bit

### DIFF
--- a/pepubot/runner.py
+++ b/pepubot/runner.py
@@ -23,6 +23,7 @@ class PePuState(Enum):
 class PePuRunner:
     def __init__(self, slack_client: slack.WebClient) -> None:
         self.slack = slack_client
+        self._state_loaded: bool = False
         self.state: PePuState = PePuState.not_started
         self.start_message: Optional[MessageInfo] = None
         self.round_participants: List[str] = []
@@ -270,6 +271,9 @@ class PePuRunner:
                 channel=message.channel, text=text)
 
     async def _load(self) -> None:
+        if self._state_loaded:
+            return
+
         storage = get_default_storage()
 
         async with self._lock:
@@ -284,6 +288,8 @@ class PePuRunner:
             MessageInfo(*start_message.split(' ')))
 
         self.round_participants = (participants or '').splitlines()
+
+        self._state_loaded = True
 
     async def _save(self) -> None:
         storage = get_default_storage()

--- a/pepubot/runner.py
+++ b/pepubot/runner.py
@@ -28,8 +28,12 @@ class PePuRunner:
         self.round_participants: List[str] = []
         self._lock = asyncio.Lock()
 
-    async def feed_message(self, event_data: Mapping[str, Any]) -> None:
-        message = Message.from_message_event(event_data)
+    async def feed_message(
+            self,
+            data: Mapping[str, Any],
+            **kwargs: object,
+    ) -> None:
+        message = Message.from_message_event(data)
         if not message:
             return
 


### PR DESCRIPTION
Fix an issue with locking by creating just a single PePuRunner on the
process start up in run_pepubot function.

Previously a new PePuRunner was created for each incoming Slack message
and the locking of the shared resources (e.g. runner state and the
lottery box) was done with an instance attribute of the
PePuRunner. Therefore there was actually a different lock for each
PePuRunner and the locking wasn't able to protect two distinct message
processing flows to mess up each other.

Also add an optimization that skips the state loading when its already
loaded.

Fixes #2